### PR TITLE
Suppress teardown exceptions when setup exception already encountered

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Once the `Managed` stack is composed, the underlying resources are built and use
 Exception behavior is as follows:
 - Exceptions during setup are thrown after already-built resources are torn down
 - Exceptions during usage are thrown after resources are torn down
-- Exceptions during teardown are thrown, but only after teardown is called on every resource. If an exception was thrown during usage, the teardown exceptions are added as suppressed exceptions on the usage exception.
+- Exceptions during teardown are thrown, but only after teardown is called on every resource. 
+- If an exception is thrown during usage, and an exception occurred during teardown, the usage exception is thrown with the teardown exception added as a suppressed exception.
+- If an exception is thrown during setup, and an exception occurred during teardown, the setup exception is thrown with the teardown exception added as a suppressed exception.
 
 For more details, see the Scaladocs.
 

--- a/managerial/src/main/scala/ca/dvgi/managerial/Managed.scala
+++ b/managerial/src/main/scala/ca/dvgi/managerial/Managed.scala
@@ -71,23 +71,19 @@ trait Managed[+T] { selfT =>
     def build() = new Resource[U] {
       private val t = selfT.build()
 
-      private var toThrow: Throwable = null
-
       private val u =
         try {
           f(t.get).build()
         } catch {
-          case throwable: Throwable =>
-            toThrow = throwable
-
+          case setupThrowable: Throwable =>
             try {
               t.teardown()
             } catch {
-              case throwable: Throwable =>
-                toThrow.addSuppressed(throwable)
+              case teardownThrowable: Throwable =>
+                setupThrowable.addSuppressed(teardownThrowable)
             }
 
-            throw toThrow
+            throw setupThrowable
         }
 
       def get = u.get

--- a/managerial/src/main/scala/ca/dvgi/managerial/Managed.scala
+++ b/managerial/src/main/scala/ca/dvgi/managerial/Managed.scala
@@ -84,11 +84,10 @@ trait Managed[+T] { selfT =>
               t.teardown()
             } catch {
               case throwable: Throwable =>
-                if (toThrow == null) toThrow = throwable
-                else toThrow.addSuppressed(throwable)
+                toThrow.addSuppressed(throwable)
             }
-            if (toThrow != null) throw toThrow
-            null.asInstanceOf[Resource[U]] // compiler doesn't know that getting here is impossible
+
+            throw toThrow
         }
 
       def get = u.get

--- a/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
+++ b/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
@@ -281,4 +281,23 @@ class ManagedTest extends munit.FunSuite {
     assertEquals(r, i)
     assert(tr.tornDown)
   }
+
+  test(
+    "An exception in the Managed setup stack, followed by an exception in the teardown stack, surfaces the setup exception"
+  ) {
+    println("start")
+    val setupException = new RuntimeException("setup exception")
+    val teardownException = new RuntimeException("teardown exception")
+
+    val m = for {
+      _ <- Managed.evalTeardown(throw teardownException)
+      _ <- Managed.evalSetup(throw setupException)
+    } yield ()
+
+    interceptMessage[RuntimeException](setupException.getMessage) {
+      m.build()
+    }
+    println("end")
+
+  }
 }

--- a/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
+++ b/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
@@ -285,7 +285,6 @@ class ManagedTest extends munit.FunSuite {
   test(
     "An exception in the Managed setup stack, followed by an exception in the teardown stack, surfaces the setup exception"
   ) {
-    println("start")
     val setupException = new RuntimeException("setup exception")
     val teardownException = new RuntimeException("teardown exception")
 
@@ -297,7 +296,5 @@ class ManagedTest extends munit.FunSuite {
     interceptMessage[RuntimeException](setupException.getMessage) {
       m.build()
     }
-    println("end")
-
   }
 }

--- a/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
+++ b/managerial/src/test/scala/ca/dvgi/managerial/ManagedTest.scala
@@ -283,7 +283,7 @@ class ManagedTest extends munit.FunSuite {
   }
 
   test(
-    "An exception in the Managed setup stack, followed by an exception in the teardown stack, surfaces the setup exception"
+    "An exception in the Managed setup stack, followed by an exception in the teardown stack, surfaces the setup exception with a suppressed teardown exception"
   ) {
     val setupException = new RuntimeException("setup exception")
     val teardownException = new RuntimeException("teardown exception")


### PR DESCRIPTION
Previously, if build/setup threw an exception, and the subsequent teardown also threw an exception, the teardown exception would be surfaced and the setup exception would be swallowed. This is not great - normally you want to know the first thing that went wrong - i.e. why did setup fail.

This PR changes the behavior to surface the setup/build exception, and add any teardown exception as a suppressed exception to it.