### PR TITLE
chore: match Mergify conditions on job name instead of Scala version

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,21 @@
 queue_rules:
   - name: dependency-update
+    # Matching the build matrix by job name keeps these conditions working
+    # across Scala version bumps. `~=` is an "any" match over the list of
+    # checks, so a single green leg satisfies it on its own; requiring no
+    # failed and no pending legs is what makes this mean "the matrix passed".
     merge_conditions:
-      - check-success=Build and Test (ubuntu-latest, 3.3.8, temurin@17)
-      - check-success=Build and Test (ubuntu-latest, 2.13.18, temurin@17)
-      - check-success=Build and Test (ubuntu-latest, 2.12.21, temurin@17)
+      - check-success~=^Build and Test \(
+      - -check-failure~=^Build and Test \(
+      - -check-pending~=^Build and Test \(
 
 pull_request_rules:
   - name: Merge using the merge queue
     conditions:
       - base=main
-      - check-success=Build and Test (ubuntu-latest, 3.3.8, temurin@17)
-      - check-success=Build and Test (ubuntu-latest, 2.13.18, temurin@17)
-      - check-success=Build and Test (ubuntu-latest, 2.12.21, temurin@17)
+      - check-success~=^Build and Test \(
+      - -check-failure~=^Build and Test \(
+      - -check-pending~=^Build and Test \(
       - author=scala-steward
     actions:
       queue:


### PR DESCRIPTION
The conditions pinned exact check names, which embed the matrix Scala version, so every version bump silently broke the merge queue until the config was updated to match.

Matching the job name by regex decouples them. `~=` is an "any" match over the check list, so `check-success` alone would pass on one green leg while another was still failing; pairing it with no-failed and no-pending is what preserves the original all-legs-green guarantee.