### PR TITLE
fix(ci): run all tests with testFull instead of test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}; test'
+        run: sbt '++ ${{ matrix.scala }}; testFull'
 
   publish:
     name: Publish Artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -82,3 +82,11 @@ ThisBuild / githubWorkflowPublish := Seq(
 // artifact upload steps embed whichever Scala version is active. That makes
 // githubWorkflowCheck fail in every cross-build job but one.
 ThisBuild / githubWorkflowArtifactUpload := false
+
+// In sbt 2, `test` only runs tests that failed before, were not run, or whose
+// dependencies changed. Its results are cached in ~/.cache/sbt, which CI
+// restores across runs, so a job can report success having run nothing.
+// `testFull` runs every test.
+ThisBuild / githubWorkflowBuild := Seq(
+  WorkflowStep.Sbt(List("testFull"), name = Some("Build project"))
+)


### PR DESCRIPTION
CI was reporting success on jobs that ran zero tests.

On the last build of `main`, the 2.12.21 leg compiled its test sources and then logged `No tests to run`, finishing green having executed nothing, while the 2.13.18 and 3.3.8 legs ran their 24 tests. Which legs actually test is not predictable from run to run, so a green check couldn't be relied on to mean the matrix was exercised.

## Cause

sbt 2 redefined `test` to mean what `testQuick` meant in sbt 1 -- "tests that either failed before, were not run, or whose transitive dependencies changed". `testQuick` is now just an alias for `test`, and the task that runs everything is the new `testFull`. The generated workflow still said `test`, which was correct under sbt 1 and silently became incremental on the upgrade.

The skip survives a clean runner because results are cached in `~/.cache/sbt`, which `sbt/setup-sbt` restores across runs (`Linux-X64-java17.0.19-sbt-diskcache-...`).

## Verification

`testFull` runs all 24 tests on each Scala version, and repeat runs don't skip:

```
2.13.18: workflowCheck=PASS  testsRun=24
2.12.21: workflowCheck=PASS  testsRun=24
3.3.8:   workflowCheck=PASS  testsRun=24
```

I also checked whether the other two CI steps were affected -- they aren't. `scalafmtCheckAll` ran fully in all three jobs and still catches a violation with a warm cache (verified by injecting one), and `githubWorkflowCheck` still fails on a modified `ci.yml`. Only `test` was impacted.
